### PR TITLE
fix fetch following error log

### DIFF
--- a/dumpia.php
+++ b/dumpia.php
@@ -197,7 +197,7 @@ class Dumpia {
 		$outJ = json_decode($out);
 
 		if(!$outJ->result === 1 || empty($outJ->fanclub_ids)) {
-			self::log(self::LOG_ERROR_FETCH_FOLLOWING);
+			self::log(self::ERR_FETCH_FOLLOWING);
 			return false;
 		}
 


### PR DESCRIPTION
When supplying a wrong key and no fanclub parameter to dumpia.php, `Dumpia::fetchFollowing()` calls `self::log()` with a wrong constant name  `self::LOG_ERROR_FETCH_FOLLOWING`, which might be a mistake for `self::ERR_FETCH_FOLLOWING`.